### PR TITLE
empty string bug fixed

### DIFF
--- a/src/main/java/io/github/gerritsmith/financeapp/controller/DeliveryController.java
+++ b/src/main/java/io/github/gerritsmith/financeapp/controller/DeliveryController.java
@@ -67,7 +67,9 @@ public class DeliveryController {
         }
         try {
             User user = userService.findUserByUsername(principal.getName());
-            double total = Double.parseDouble(deliveryFormDTO.getTotal());
+            String totalString = deliveryFormDTO.getTotal();
+            totalString = totalString.isEmpty() ? "0" : totalString;
+            double total = Double.parseDouble(totalString);
             Delivery newDelivery = new Delivery(user,
                                                 deliveryFormDTO.getDate(),
                                                 deliveryFormDTO.getTime(),


### PR DESCRIPTION
On add new delivery form leaving the total field empty would crash the app when trying to parse as a double, it is now fixed.