### PR TITLE
security ignores js directory

### DIFF
--- a/src/main/java/io/github/gerritsmith/financeapp/configuration/SecurityConfiguration.java
+++ b/src/main/java/io/github/gerritsmith/financeapp/configuration/SecurityConfiguration.java
@@ -52,7 +52,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
     @Override
     public void configure(WebSecurity web) {
         web.ignoring()
-                .antMatchers("/css/**");
+                .antMatchers("/css/**", "/js/**");
     }
 
 }


### PR DESCRIPTION
Bug: Login autoredirected to js file
Fix: spring security now ignores the js directory
