### PR TITLE
datalist options match fields used to check uniqueness

### DIFF
--- a/src/main/resources/templates/delivery/form.html
+++ b/src/main/resources/templates/delivery/form.html
@@ -162,7 +162,7 @@
             <option data-value="-1">Select Dropoff Location</option>
             <option th:each="dropoffLocation : ${dropoffLocations}"
                     th:data-value="${dropoffLocation.id}"
-                    th:text="${dropoffLocation.address}">Dropoff Location Option</option>
+                    th:text="${dropoffLocation.address + ' ' + dropoffLocation.name + ' ' + dropoffLocation.apt}">Dropoff Location Option</option>
         </datalist>
 
         <div class="form-group" th:unless="${#request.requestURI.endsWith('new')}">


### PR DESCRIPTION
datalist options for dropoff location are now built from:
- address
- name
- apt
the same fields used to check if a dropoff location already exists, so the combination should be unique.